### PR TITLE
Image coordinate update 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,17 @@
 repos:
+   # remove unused imports
+  - repo: https://github.com/hadialqattan/pycln.git
+    rev: v2.1.3
+    hooks:
+      - id: pycln
+
+  # import formatter
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+
   # Code formatter for both python files and jupyter notebooks
   - repo: https://github.com/psf/black
     rev: 22.10.0
@@ -14,7 +27,16 @@ repos:
       - id: sourcery
         args: [--diff=git diff HEAD, --in-place, --no-summary]
 
-#  additional hooks found with in the pre-commit lib
+  # python linter
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.245'
+    hooks:
+      - id: ruff
+
+  #  additional hooks found with in the pre-commit lib
+  # -- remove trailing spaces
+  # -- remove mix line ending (tabs and spaces)
+  # -- JSON formatter
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
@@ -27,3 +49,4 @@ repos:
           - "--autofix"
           - "--indent=4"
           - "--no-sort-keys"
+

--- a/env.yaml
+++ b/env.yaml
@@ -4,12 +4,12 @@ channels:
   - anaconda
   - defaults
 dependencies:
-  - python>=3.10
+  - python=3.10
   - pip
   - numpy
   - pandas
   - pillow
-  # - ipykernel
+  - ipykernel
   - pip:
       - PyQt5
       - pre-commit

--- a/notebooks/00_extract_coordinate_images.ipynb
+++ b/notebooks/00_extract_coordinate_images.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "from typing import List, Tuple, Optional, TypeGuard\n",
     "\n",
     "# user module imports\n",
     "sys.path.append(\"../\")\n",
@@ -87,7 +86,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "macrophage-striation",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -101,12 +100,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "04db14ac345d4890825c5eac5e15e8d454c68e836c790ddb03cf13c85454c698"
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
    }
   }
  },

--- a/notebooks/00_extract_coordinate_images.ipynb
+++ b/notebooks/00_extract_coordinate_images.ipynb
@@ -70,7 +70,7 @@
     {
      "data": {
       "text/plain": [
-       "PosixPath('/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/test_image_coords.json')"
+       "PosixPath('/home/erikserrano/Development/macrophage-striation-analysis/notebooks/test_image_coords.json')"
       ]
      },
      "execution_count": 4,
@@ -86,7 +86,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "macrophage-striation",
    "language": "python",
    "name": "python3"
   },
@@ -100,12 +100,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    "hash": "91048f8dfba935495c60b6fa4ebcc53cf3f516be88855f0ecbe417c32909c255"
    }
   }
  },

--- a/notebooks/test_image_coords.json
+++ b/notebooks/test_image_coords.json
@@ -1,892 +1,8 @@
 {
-    "cell_image_1.tiff": [
-        {
-            "img_id": 1,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                0,
-                256,
-                256
-            ]
-        },
-        {
-            "img_id": 2,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                256,
-                256,
-                512
-            ]
-        },
-        {
-            "img_id": 3,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                512,
-                256,
-                768
-            ]
-        },
-        {
-            "img_id": 4,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                768,
-                256,
-                1024
-            ]
-        },
-        {
-            "img_id": 5,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                1024,
-                256,
-                1280
-            ]
-        },
-        {
-            "img_id": 6,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                1280,
-                256,
-                1536
-            ]
-        },
-        {
-            "img_id": 7,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                0,
-                1536,
-                256,
-                1792
-            ]
-        },
-        {
-            "img_id": 8,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                0,
-                512,
-                256
-            ]
-        },
-        {
-            "img_id": 9,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                256,
-                512,
-                512
-            ]
-        },
-        {
-            "img_id": 10,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                512,
-                512,
-                768
-            ]
-        },
-        {
-            "img_id": 11,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                768,
-                512,
-                1024
-            ]
-        },
-        {
-            "img_id": 12,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                1024,
-                512,
-                1280
-            ]
-        },
-        {
-            "img_id": 13,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                1280,
-                512,
-                1536
-            ]
-        },
-        {
-            "img_id": 14,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                256,
-                1536,
-                512,
-                1792
-            ]
-        },
-        {
-            "img_id": 15,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                0,
-                768,
-                256
-            ]
-        },
-        {
-            "img_id": 16,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                256,
-                768,
-                512
-            ]
-        },
-        {
-            "img_id": 17,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                512,
-                768,
-                768
-            ]
-        },
-        {
-            "img_id": 18,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                768,
-                768,
-                1024
-            ]
-        },
-        {
-            "img_id": 19,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                1024,
-                768,
-                1280
-            ]
-        },
-        {
-            "img_id": 20,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                1280,
-                768,
-                1536
-            ]
-        },
-        {
-            "img_id": 21,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                512,
-                1536,
-                768,
-                1792
-            ]
-        },
-        {
-            "img_id": 22,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                0,
-                1024,
-                256
-            ]
-        },
-        {
-            "img_id": 23,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                256,
-                1024,
-                512
-            ]
-        },
-        {
-            "img_id": 24,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                512,
-                1024,
-                768
-            ]
-        },
-        {
-            "img_id": 25,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                768,
-                1024,
-                1024
-            ]
-        },
-        {
-            "img_id": 26,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                1024,
-                1024,
-                1280
-            ]
-        },
-        {
-            "img_id": 27,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                1280,
-                1024,
-                1536
-            ]
-        },
-        {
-            "img_id": 28,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                768,
-                1536,
-                1024,
-                1792
-            ]
-        },
-        {
-            "img_id": 29,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                0,
-                1280,
-                256
-            ]
-        },
-        {
-            "img_id": 30,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                256,
-                1280,
-                512
-            ]
-        },
-        {
-            "img_id": 31,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                512,
-                1280,
-                768
-            ]
-        },
-        {
-            "img_id": 32,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                768,
-                1280,
-                1024
-            ]
-        },
-        {
-            "img_id": 33,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                1024,
-                1280,
-                1280
-            ]
-        },
-        {
-            "img_id": 34,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                1280,
-                1280,
-                1536
-            ]
-        },
-        {
-            "img_id": 35,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1024,
-                1536,
-                1280,
-                1792
-            ]
-        },
-        {
-            "img_id": 36,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                0,
-                1536,
-                256
-            ]
-        },
-        {
-            "img_id": 37,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                256,
-                1536,
-                512
-            ]
-        },
-        {
-            "img_id": 38,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                512,
-                1536,
-                768
-            ]
-        },
-        {
-            "img_id": 39,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                768,
-                1536,
-                1024
-            ]
-        },
-        {
-            "img_id": 40,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                1024,
-                1536,
-                1280
-            ]
-        },
-        {
-            "img_id": 41,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                1280,
-                1536,
-                1536
-            ]
-        },
-        {
-            "img_id": 42,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1280,
-                1536,
-                1536,
-                1792
-            ]
-        },
-        {
-            "img_id": 43,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                0,
-                1792,
-                256
-            ]
-        },
-        {
-            "img_id": 44,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                256,
-                1792,
-                512
-            ]
-        },
-        {
-            "img_id": 45,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                512,
-                1792,
-                768
-            ]
-        },
-        {
-            "img_id": 46,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                768,
-                1792,
-                1024
-            ]
-        },
-        {
-            "img_id": 47,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                1024,
-                1792,
-                1280
-            ]
-        },
-        {
-            "img_id": 48,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                1280,
-                1792,
-                1536
-            ]
-        },
-        {
-            "img_id": 49,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1536,
-                1536,
-                1792,
-                1792
-            ]
-        },
-        {
-            "img_id": 50,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                0,
-                2048,
-                256
-            ]
-        },
-        {
-            "img_id": 51,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                256,
-                2048,
-                512
-            ]
-        },
-        {
-            "img_id": 52,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                512,
-                2048,
-                768
-            ]
-        },
-        {
-            "img_id": 53,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                768,
-                2048,
-                1024
-            ]
-        },
-        {
-            "img_id": 54,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                1024,
-                2048,
-                1280
-            ]
-        },
-        {
-            "img_id": 55,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                1280,
-                2048,
-                1536
-            ]
-        },
-        {
-            "img_id": 56,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                1792,
-                1536,
-                2048,
-                1792
-            ]
-        },
-        {
-            "img_id": 57,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                0,
-                2304,
-                256
-            ]
-        },
-        {
-            "img_id": 58,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                256,
-                2304,
-                512
-            ]
-        },
-        {
-            "img_id": 59,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                512,
-                2304,
-                768
-            ]
-        },
-        {
-            "img_id": 60,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                768,
-                2304,
-                1024
-            ]
-        },
-        {
-            "img_id": 61,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                1024,
-                2304,
-                1280
-            ]
-        },
-        {
-            "img_id": 62,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                1280,
-                2304,
-                1536
-            ]
-        },
-        {
-            "img_id": 63,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
-            "img_size": [
-                256,
-                256
-            ],
-            "crop_position": [
-                2048,
-                1536,
-                2304,
-                1792
-            ]
-        }
-    ],
     "cell_image_2.tiff": [
         {
             "img_id": 1,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -896,11 +12,12 @@
                 0,
                 256,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 2,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -910,11 +27,12 @@
                 256,
                 256,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 3,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -924,11 +42,12 @@
                 512,
                 256,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 4,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -938,11 +57,12 @@
                 768,
                 256,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 5,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -952,11 +72,12 @@
                 0,
                 512,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 6,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -966,11 +87,12 @@
                 256,
                 512,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 7,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -980,11 +102,12 @@
                 512,
                 512,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 8,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -994,11 +117,12 @@
                 768,
                 512,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 9,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1008,11 +132,12 @@
                 0,
                 768,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 10,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1022,11 +147,12 @@
                 256,
                 768,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 11,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1036,11 +162,12 @@
                 512,
                 768,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 12,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1050,11 +177,12 @@
                 768,
                 768,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 13,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1064,11 +192,12 @@
                 0,
                 1024,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 14,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1078,11 +207,12 @@
                 256,
                 1024,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 15,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1092,11 +222,12 @@
                 512,
                 1024,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 16,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1106,11 +237,12 @@
                 768,
                 1024,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 17,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1120,11 +252,12 @@
                 0,
                 1280,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 18,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1134,11 +267,12 @@
                 256,
                 1280,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 19,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1148,11 +282,12 @@
                 512,
                 1280,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 20,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1162,11 +297,12 @@
                 768,
                 1280,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 21,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1176,11 +312,12 @@
                 0,
                 1536,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 22,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1190,11 +327,12 @@
                 256,
                 1536,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 23,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1204,11 +342,12 @@
                 512,
                 1536,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 24,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1218,11 +357,12 @@
                 768,
                 1536,
                 1024
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 25,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1232,11 +372,12 @@
                 0,
                 1792,
                 256
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 26,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1246,11 +387,12 @@
                 256,
                 1792,
                 512
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 27,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1260,11 +402,12 @@
                 512,
                 1792,
                 768
-            ]
+            ],
+            "classification": null
         },
         {
             "img_id": 28,
-            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_2.tiff",
             "img_size": [
                 256,
                 256
@@ -1274,7 +417,955 @@
                 768,
                 1792,
                 1024
-            ]
+            ],
+            "classification": null
+        }
+    ],
+    "cell_image_1.tiff": [
+        {
+            "img_id": 1,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                0,
+                256,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 2,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                256,
+                256,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 3,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                512,
+                256,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 4,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                768,
+                256,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 5,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                1024,
+                256,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 6,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                1280,
+                256,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 7,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                0,
+                1536,
+                256,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 8,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                0,
+                512,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 9,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                256,
+                512,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 10,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                512,
+                512,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 11,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                768,
+                512,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 12,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                1024,
+                512,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 13,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                1280,
+                512,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 14,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                256,
+                1536,
+                512,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 15,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                0,
+                768,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 16,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                256,
+                768,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 17,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                512,
+                768,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 18,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                768,
+                768,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 19,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                1024,
+                768,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 20,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                1280,
+                768,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 21,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                512,
+                1536,
+                768,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 22,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                0,
+                1024,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 23,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                256,
+                1024,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 24,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                512,
+                1024,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 25,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                768,
+                1024,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 26,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                1024,
+                1024,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 27,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                1280,
+                1024,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 28,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                768,
+                1536,
+                1024,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 29,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                0,
+                1280,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 30,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                256,
+                1280,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 31,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                512,
+                1280,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 32,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                768,
+                1280,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 33,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                1024,
+                1280,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 34,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                1280,
+                1280,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 35,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1024,
+                1536,
+                1280,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 36,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                0,
+                1536,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 37,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                256,
+                1536,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 38,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                512,
+                1536,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 39,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                768,
+                1536,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 40,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                1024,
+                1536,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 41,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                1280,
+                1536,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 42,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1280,
+                1536,
+                1536,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 43,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                0,
+                1792,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 44,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                256,
+                1792,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 45,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                512,
+                1792,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 46,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                768,
+                1792,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 47,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                1024,
+                1792,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 48,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                1280,
+                1792,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 49,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1536,
+                1536,
+                1792,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 50,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                0,
+                2048,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 51,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                256,
+                2048,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 52,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                512,
+                2048,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 53,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                768,
+                2048,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 54,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                1024,
+                2048,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 55,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                1280,
+                2048,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 56,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                1792,
+                1536,
+                2048,
+                1792
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 57,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                0,
+                2304,
+                256
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 58,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                256,
+                2304,
+                512
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 59,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                512,
+                2304,
+                768
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 60,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                768,
+                2304,
+                1024
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 61,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                1024,
+                2304,
+                1280
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 62,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                1280,
+                2304,
+                1536
+            ],
+            "classification": null
+        },
+        {
+            "img_id": 63,
+            "file_name": "/home/erikserrano/Development/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
+            "img_size": [
+                256,
+                256
+            ],
+            "crop_position": [
+                2048,
+                1536,
+                2304,
+                1792
+            ],
+            "classification": null
         }
     ]
 }

--- a/src/structs/selections.py
+++ b/src/structs/selections.py
@@ -4,14 +4,15 @@ Module: selection.py
 Contains data structure and functions that focuses on obtaining metadata
 from cropped images.
 """
-from dataclasses import dataclass
-from typing import Tuple, Optional
+from dataclasses import dataclass, field
+from typing import Optional
 
 
 @dataclass(slots=True)
 class ImageCropSelection:
     """Data structure containing metadata information of the selected
     cropped images.
+
 
     Attributes:
     -----------
@@ -21,15 +22,28 @@ class ImageCropSelection:
     file_name : str
         Name of the file where the cropped image came from.
 
-    crop_position : Tuple[int, int, int, int]
+    image_size : tuple [int, int]
+        Image crop size
+
+    crop_position : tuple[int, int, int, int]
         The crop position used to select cropped image
+
+    __classification : None [Private attribute]
+        This attribute is initialized as a private attribute used for declaring
+        whether the cropped image is either positive or negative for a specific
+        characterization. By default it will be set a "None" indicating that no
+        classification has been performed to the specific cropped image. 
+
     """
 
     img_id: int
     file_name: str
     img_size: tuple[int, int]
-    crop_position: Tuple[int, int, int, int]
-    classification: Optional[None | int] = None
+    crop_position: tuple[int, int, int, int]
+    
+    # private attribute
+    __classification = None
+    
 
     def to_dict(self) -> dict:
         """Converts `ImageCropSelection` entry into a dictionary type"""

--- a/src/structs/selections.py
+++ b/src/structs/selections.py
@@ -5,18 +5,31 @@ Contains data structure and functions that focuses on obtaining metadata
 from cropped images.
 """
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Tuple, Optional
 
 
 @dataclass(slots=True)
 class ImageCropSelection:
     """Data structure containing metadata information of the selected
-    cropped images."""
+    cropped images.
+
+    Attributes:
+    -----------
+    img_id : int
+        unique number id that represents the cropped image
+
+    file_name : str
+        Name of the file where the cropped image came from.
+
+    crop_position : Tuple[int, int, int, int]
+        The crop position used to select cropped image
+    """
 
     img_id: int
     file_name: str
     img_size: tuple[int, int]
     crop_position: Tuple[int, int, int, int]
+    classification: Optional[None | int] = None
 
     def to_dict(self) -> dict:
         """Converts `ImageCropSelection` entry into a dictionary type"""
@@ -25,4 +38,5 @@ class ImageCropSelection:
             file_name=self.file_name,
             img_size=self.img_size,
             crop_position=self.crop_position,
+            classification=self.__classification
         )

--- a/src/ui/macstr_ui.py
+++ b/src/ui/macstr_ui.py
@@ -12,6 +12,7 @@ This image are used as placeholders where the cropped images should be placed.
 
 """
 import sys
+
 import yaml
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -21,7 +22,7 @@ class Ui_MainWindow(object):
 
         # loading in the JSON data
         with open("../../notebooks/test_image_coords.json", "r") as contents:
-            image_data = yaml.safe_load(contents)
+            image_data = yaml.safe_load(contents)  # noqa: F841
 
         # creating main GUI window
         MainWindow.setObjectName("MacStr")


### PR DESCRIPTION
## About this PR

This PR adds another attribute named as `classification` within the `image-cord` file. 

## Motivation and implementation
This additional attribute will allow for the program to identify which cropped images are considered as positive or negative for straition patterns. 

This also provides room for extensibility if someone were to share the `image-coord` files with someone else and will know which image and coordinate positions are labeled. 

Below is an example of the `image-coord` file with the added `classification` attribute:
```json
{
    "cell_image_1.tiff": [
        {
            "img_id": 1,
            "file_name": "/Users/erikserrano/Development/Projects/macrophage-striation-analysis/notebooks/sample_data/cell_image_1.tiff",
            "img_size": [
                256,
                256
            ],
            "crop_position": [
                0,
                0,
                256,
                256
            ],
            "classification": null
       }
```

## What's new?

**ImageCropSelection** 
- added attribute documentation 
- `to_dict` now includes `classification` attribute 

**pre-commit configuration**

- added `Ruff` as the dedicated python linter
- added `isort` for import formatting
- added `pyc1n` for removal of unused imports 
